### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# fluent-plugin-mysql-prepared-statement [![Build Status](https://secure.travis-ci.org/toyama0919/fluent-plugin-mysql-prepared-statement.png?branch=master)](http://travis-ci.org/toyama0919/fluent-plugin-mysql-prepared-statement)
+# fluent-plugin-mysql-prepared-statement, a plugin for [Fluentd](http://fluentd.org) [![Build Status](https://secure.travis-ci.org/toyama0919/fluent-plugin-mysql-prepared-statement.png?branch=master)](http://travis-ci.org/toyama0919/fluent-plugin-mysql-prepared-statement)
 
 
 fluent plugin mysql prepared statement query


### PR DESCRIPTION
I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.
