### PR TITLE
Add test unit gem dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ rvm:
   - 1.9.2
   - 1.9.3
   - 2.0.0
+  - 2.1
+  - 2.2
 gemfile:
   - Gemfile
 script: "rake test"

--- a/fluent-plugin-mysql-prepared-statement.gemspec
+++ b/fluent-plugin-mysql-prepared-statement.gemspec
@@ -22,5 +22,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rspec"
   gem.add_development_dependency "spork"
   gem.add_development_dependency "pry"
+  gem.add_development_dependency "test-unit", ">= 3.1.0"
 
 end


### PR DESCRIPTION
Because Ruby 2.2 does not provide minitest with test-unit compatible layer.

BTW, recent Fluentd depends `string-scrub` gem which supports Ruby 1.9.3 or later.
Should I remove Ruby 1.9.2 task in Travis? 
