### PR TITLE
Support secret parameter feature

### DIFF
--- a/lib/fluent/plugin/out_mysql_prepared_statement.rb
+++ b/lib/fluent/plugin/out_mysql_prepared_statement.rb
@@ -8,7 +8,7 @@ module Fluent
     config_param :port, :integer, :default => 3306
     config_param :database, :string
     config_param :username, :string
-    config_param :password, :string, :default => ''
+    config_param :password, :string, :default => '', :secret => true
 
     config_param :key_names, :string, :default => nil
     config_param :sql, :string, :default => nil


### PR DESCRIPTION
`password` contains sensitive information.
This parameter should be concealed with secret parameter feature.
